### PR TITLE
DORIS-2034: [Android] Avoid WebvttDecoder failure while parsing VTT styles

### DIFF
--- a/libraries/common/src/main/java/androidx/media3/common/util/ColorParser.java
+++ b/libraries/common/src/main/java/androidx/media3/common/util/ColorParser.java
@@ -18,6 +18,7 @@ package androidx.media3.common.util;
 import android.graphics.Color;
 import android.text.TextUtils;
 import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
 import com.google.common.base.Ascii;
 import java.util.HashMap;
 import java.util.Map;
@@ -78,6 +79,10 @@ public final class ColorParser {
     Assertions.checkArgument(!TextUtils.isEmpty(colorExpression));
     colorExpression = colorExpression.replace(" ", "");
     if (colorExpression.charAt(0) == '#') {
+      if (colorExpression.length() == 4 || colorExpression.length() == 5) {
+        // #RGB(A) to #RRGGBB(AA)
+        colorExpression = duplicateHexDigits(colorExpression);
+      }
       // Parse using Long to avoid failure when colorExpression is greater than #7FFFFFFF.
       int color = (int) Long.parseLong(colorExpression.substring(1), 16);
       if (colorExpression.length() == 7) {
@@ -119,6 +124,19 @@ public final class ColorParser {
       }
     }
     throw new IllegalArgumentException();
+  }
+
+  private static String duplicateHexDigits(@NonNull String hexString) {
+    if (hexString.length() == 0 || hexString.charAt(0) != '#') {
+      throw new IllegalArgumentException();
+    }
+    StringBuilder result = new StringBuilder();
+    result.append("#");
+    for (int i = 1; i < hexString.length(); i++) {
+      char c = hexString.charAt(i);
+      result.append(c).append(c);
+    }
+    return result.toString();
   }
 
   static {

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/webvtt/WebvttCssParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/webvtt/WebvttCssParser.java
@@ -193,9 +193,17 @@ import java.util.regex.Pattern;
     }
     // At this point we have a presumably valid declaration, we need to parse it and fill the style.
     if (PROPERTY_COLOR.equals(property)) {
-      style.setFontColor(ColorParser.parseCssColor(value));
+      try {
+        style.setFontColor(ColorParser.parseCssColor(value));
+      } catch (IllegalArgumentException ex) {
+        // Ignore exception.
+      }
     } else if (PROPERTY_BGCOLOR.equals(property)) {
-      style.setBackgroundColor(ColorParser.parseCssColor(value));
+      try {
+        style.setBackgroundColor(ColorParser.parseCssColor(value));
+      } catch (IllegalArgumentException ex) {
+        // Ignore exception.
+      }
     } else if (PROPERTY_RUBY_POSITION.equals(property)) {
       if (VALUE_OVER.equals(value)) {
         style.setRubyPosition(TextAnnotation.POSITION_BEFORE);

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/text/webvtt/WebvttCueParser.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/text/webvtt/WebvttCueParser.java
@@ -517,8 +517,9 @@ public final class WebvttCueParser {
       case TAG_CLASS:
       case TAG_ITALIC:
       case TAG_LANG:
-      case TAG_RUBY:
-      case TAG_RUBY_TEXT:
+      // Ignore <ruby> and <rt> tags, see DORIS-2034.
+      // case TAG_RUBY:
+      // case TAG_RUBY_TEXT:
       case TAG_UNDERLINE:
       case TAG_VOICE:
         return true;


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-2034

* Add support for 3/4 digit hex color expressions: RGB(A) -> RRGGBB(AA)
* Ignore color parsing exceptions on font- and background colors, e.g. hsl(268.71deg 100% 50%)
* Ignore ruby/rt tags for now as the decoder fails on cues with multiple ruby tags

Subtitle used for testing: `https://sample-videos-zyrkp2nj.s3.eu-west-1.amazonaws.com/web-vtt-test/permitted-props-v2.vtt`


https://github.com/DiceTechnology/androidx-media/assets/3526708/8dba0f5c-67f9-4ccf-a18d-68108a187f79
