### PR TITLE
chore: try to fix the offset issue of cmaf emsg samples.

### DIFF
--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/HlsSampleStreamWrapper.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/HlsSampleStreamWrapper.java
@@ -1889,7 +1889,11 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
       int sampleSize = sampleForDelegate.bytesLeft();
 
       delegate.sampleData(sampleForDelegate, sampleSize);
-      delegate.sampleMetadata(timeUs, flags, sampleSize, offset, cryptoData);
+      // To fix offset issue of cmaf emsg samples, we should pass offset to 0, details tickets:
+      // https://github.com/androidx/media/issues/1002
+      // https://dicetech.atlassian.net/browse/DORIS-2103
+      delegate.sampleMetadata(timeUs, flags, sampleSize, 0, cryptoData);
+      // delegate.sampleMetadata(timeUs, flags, sampleSize, offset, cryptoData);
     }
 
     @Override


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-2103

Start the yospace `test mp4` stream we got the playback exception sometimes, but sometime it starts normally.
This issue may caused by the pending metadata samples within fmp4 extractor.

Our video chunk contain video + emsg samples and audio chuck only contain audio samples.  
If the first audio chuck is extracted before video chuck, and then no pending metadata (because at the time of first video chuck extraced the timeadjuster had inited, and the emsg can be output to sample queue directly), but if the video chuck is extracted first and then we will have pending metadata samples. It will break the playback. When we output the pending metadata samples to data queue, media 1.2.0 passed wrong `offset`.

We fixed it and now this playback of `test mp4` stream works normally.