### PR TITLE
Feat/doris 2176 support mixed ts cmaf stream

### DIFF
--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -118,7 +118,9 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     this.mediaDrm = new MediaDrm(adjustUuid(uuid));
     // Creators of an instance automatically acquire ownership of the created instance.
     referenceCount = 1;
-    if (C.WIDEVINE_UUID.equals(uuid) && needsForceWidevineL3Workaround()) {
+    // Add the initial check about this device support L1 or only L3.
+    boolean mediaDrmL3 = "L3".equalsIgnoreCase(getPropertyString("securityLevel"));
+    if (C.WIDEVINE_UUID.equals(uuid) && (mediaDrmL3 || needsForceWidevineL3Workaround())) {
       forceWidevineL3(mediaDrm);
     }
   }

--- a/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
+++ b/libraries/exoplayer/src/main/java/androidx/media3/exoplayer/drm/FrameworkMediaDrm.java
@@ -120,7 +120,7 @@ public final class FrameworkMediaDrm implements ExoMediaDrm {
     referenceCount = 1;
     // Add the initial check about this device support L1 or only L3.
     boolean mediaDrmL3 = "L3".equalsIgnoreCase(getPropertyString("securityLevel"));
-    if (C.WIDEVINE_UUID.equals(uuid) && (mediaDrmL3 || needsForceWidevineL3Workaround())) {
+    if (C.WIDEVINE_UUID.equals(uuid) && !mediaDrmL3 && needsForceWidevineL3Workaround()) {
       forceWidevineL3(mediaDrm);
     }
   }

--- a/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
+++ b/libraries/exoplayer_hls/src/main/java/androidx/media3/exoplayer/hls/playlist/HlsPlaylistParser.java
@@ -853,6 +853,8 @@ public final class HlsPlaylistParser implements ParsingLoadable.Parser<HlsPlayli
         playlistDiscontinuitySequence = Integer.parseInt(line.substring(line.indexOf(':') + 1));
       } else if (line.equals(TAG_DISCONTINUITY) && !discontinuityAfterSkip) {
         relativeDiscontinuitySequence++;
+        // To fix the playback issue on the mixed-ts-cmaf stream.
+        initializationSegment = null;
       } else if (line.startsWith(TAG_PROGRAM_DATE_TIME)) {
         segmentStartTimeUtcUs = Util.msToUs(Util.parseXsDateTime(line.substring(line.indexOf(':') + 1)));
         // Calc playlist start time with latest value of #EXT-X-PROGRAM-DATE-TIME tag, instead first value.


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-2176

Try to support some yospace ssai steam which mixed clear ad + cmaf drm content on exoplayer.
We should load `init` segment with `#EXT-X-DISCONTINUITY`.