### PR TITLE
DORIS-2468: Fix cropped cues

### DIFF
--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -917,6 +917,20 @@
         "subtitle_language": "en"
       },
       {
+        "name": "WebVTT Auto Line",
+        "uri": "https://hsec92v41d.execute-api.eu-west-1.amazonaws.com/Prod/auto-live/big-buck-bunny/master.m3u8?debug&streamUptime=1400&streamEndAfter=1400",
+        "subtitle_uri": "https://sample-videos-zyrkp2nj.s3.eu-west-1.amazonaws.com/test-20240403/line-position.vtt",
+        "subtitle_mime_type": "text/vtt",
+        "subtitle_language": "en"
+      },
+      {
+        "name": "WebVTT Arabic",
+        "uri": "https://hsec92v41d.execute-api.eu-west-1.amazonaws.com/Prod/auto-live/big-buck-bunny/master.m3u8?debug&streamUptime=1400&streamEndAfter=1400",
+        "subtitle_uri": "https://dve-subtitles.imggaming.com/680850/927716/vtt/subtitle-ar-320516-1726134946702.vtt",
+        "subtitle_mime_type": "text/vtt",
+        "subtitle_language": "en"
+      },
+      {
         "name": "WebVTT Japanese features",
         "uri": "https://html5demos.com/assets/dizzy.mp4",
         "subtitle_uri": "https://storage.googleapis.com/exoplayer-test-media-1/webvtt/japanese.vtt",


### PR DESCRIPTION
**Ticket:** https://dicetech.atlassian.net/browse/DORIS-2468

**Sample .vtt file:**
```
WEBVTT

STYLE
::cue(.l1) { background: #FF000077; }
::cue(.l2) { background: #00FF0077; }
::cue(.l3) { background: #0000FF77; }
::cue(.l4) { background: #FFFF0077; }
::cue(.l5) { background: #00FFFF77; }
::cue(.l6) { background: #FF00FF77; }

00:00:00.000 --> 00:00:10.000 line:-1
<c.l1>line: -1 ================</c>

00:00:00.000 --> 00:00:05.000 line:-2
<c.l2>line: -2 =========</c>

00:00:00.000 --> 00:00:07.000 line:-3
<c.l3>line: -3 =====</c>

00:00:01.000 --> 00:00:15.000
<c.l4>line: auto #1 ===</c>

00:00:01.000 --> 00:00:15.000
<c.l5>line: auto #2 ===</c>

00:00:01.000 --> 00:00:15.000
<c.l6>line: auto #3 ===</c>
```

**Default behavior**

As per [WebVtt](https://www.w3.org/TR/webvtt1/) standards
> Positive line numbers count from the start of the video viewport (the first line is numbered 0), negative line numbers from the end of the video viewport (the last line is numbered −1).

Cues with unset `line` attribute (also called auto line) are automatically getting a `line` attribute starting from -1, making them to stack on each other from the bottom.
```java
for (int i = 0; i < cuesWithUnsetLine.size(); i++) {
    Cue cue = cuesWithUnsetLine.get(i).cue;
    currentCues.add(cue.buildUpon().setLine((float) (-1 - i), Cue.LINE_TYPE_NUMBER).build());
}
```
However this caused a cropped cue in certain scenarios at the very bottom (see the ticket).

**The fix:**

We still respect the `line` attribute on a cue if it's present (both `LINE_TYPE_FRACTION` and `LINE_TYPE_NUMBER`), but if it's an auto line then we start assigning the `line` from -2 (instead of -1 to avoid any cropping) and dynamically find the next available `line` number to avoid overlaps with other cues.

**Screen recordings:**

https://github.com/user-attachments/assets/b6304398-a668-4d0b-a66b-3d054732ff63

https://github.com/user-attachments/assets/c98106b0-58df-4bba-895f-02239fe85c5d


