### PR TITLE
add jetbrains.kotlin jdk7 and jdk8 in workaround.gradle

### DIFF
--- a/missing_aar_type_workaround.gradle
+++ b/missing_aar_type_workaround.gradle
@@ -30,6 +30,8 @@ def addMissingAarTypeToXml(xml) {
         "org.mockito:mockito-core",
         "org.robolectric:robolectric",
         "com.github.philburk:jsyn",
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     ]
     // Dependencies that have AAR files.
     def aar_dependencies = [


### PR DESCRIPTION
fix jitpack build error.
add 
` "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
   "org.jetbrains.kotlin:kotlin-stdlib-jdk8"`
to missing_aar_type_workaround.gradle