### PR TITLE
Fix/preroll flash when resume vod

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 project.ext {
-    releaseVersion = '1.4.1-dr5'
-    releaseVersionCode = 1_004_001_5_00
+    releaseVersion = '1.4.1-dr6'
+    releaseVersionCode = 1_004_001_6_00
     minSdkVersion = 19
     // See https://developer.android.com/training/cars/media/automotive-os#automotive-module
     automotiveMinSdkVersion = 28

--- a/libraries/ui/src/main/java/androidx/media3/ui/PlayerView.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/PlayerView.java
@@ -339,6 +339,9 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
   private boolean controllerHideOnTouch;
   private int textureViewRotation;
 
+  /** Indicates if the playback media is currently prepared. */
+  private boolean isPlaybackPrepared = true;
+
   public PlayerView(Context context) {
     this(context, /* attrs= */ null);
   }
@@ -1309,6 +1312,22 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
   }
 
   /**
+   * Sets whether the the playback media is currently prepared.
+   * Emmit PREPARING state if first timeline is ready.
+   * Emmit PREPARED state if first frame is rendered or the initial resume has completed if have.
+   *
+   * @param prepared Indicates if the playback media is currently prepared.
+   */
+  public void setPlaybackPrepared(boolean prepared) {
+    if (prepared && !isPlaybackPrepared) {
+      mainLooperHandler.postDelayed(() -> isPlaybackPrepared = true, 200L);
+      componentListener.hideShutterView();
+    } else if (!prepared && isPlaybackPrepared) {
+      isPlaybackPrepared = false;
+    }
+  }
+
+  /**
    * Sets the {@link AspectRatioFrameLayout.AspectRatioListener}.
    *
    * @param listener The listener to be notified about aspect ratios changes of the video content or
@@ -1904,6 +1923,12 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
 
     @Override
     public void onRenderedFirstFrame() {
+      if (isPlaybackPrepared) {
+        hideShutterView();
+      }
+    }
+
+    private void hideShutterView() {
       if (shutterView != null) {
         shutterView.setVisibility(INVISIBLE);
         if (hasSelectedImageTrack()) {

--- a/libraries/ui/src/main/java/androidx/media3/ui/PlayerView.java
+++ b/libraries/ui/src/main/java/androidx/media3/ui/PlayerView.java
@@ -1313,8 +1313,6 @@ public class PlayerView extends FrameLayout implements AdViewProvider {
 
   /**
    * Sets whether the the playback media is currently prepared.
-   * Emmit PREPARING state if first timeline is ready.
-   * Emmit PREPARED state if first frame is rendered or the initial resume has completed if have.
    *
    * @param prepared Indicates if the playback media is currently prepared.
    */


### PR DESCRIPTION
## Description

- fix: preroll flashes before midroll when resuming a VOD

## JIRA
[DORIS-3011](https://dicetech.atlassian.net/browse/DORIS-3011)
[DORIS-3012](https://dicetech.atlassian.net/browse/DORIS-3012)

[DORIS-3011]: https://dicetech.atlassian.net/browse/DORIS-3011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DORIS-3012]: https://dicetech.atlassian.net/browse/DORIS-3012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ