### PR TITLE
[DORIS-3076] Fix: tolerate malformed negative trun values on text tracks

### DIFF
--- a/constants.gradle
+++ b/constants.gradle
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 project.ext {
-    releaseVersion = '1.8.0-dr2'
-    releaseVersionCode = 1_008_000_3_02
+    releaseVersion = '1.8.0-dr3'
+    releaseVersionCode = 1_008_000_3_03
     minSdkVersion = 21
     // See https://developer.android.com/training/cars/media/automotive-os#automotive-module
     automotiveMinSdkVersion = 28

--- a/demos/main/src/main/assets/media.exolist.json
+++ b/demos/main/src/main/assets/media.exolist.json
@@ -939,6 +939,10 @@
     "name": "Subtitles",
     "samples": [
       {
+        "name": "DASH - malformed WebVTT (negative trun values)",
+        "uri": "https://sample-videos-zyrkp2nj.s3.eu-west-1.amazonaws.com/support-22097/manifest_crash.mpd"
+      },
+      {
         "name": "TTML positioning",
         "uri": "https://html5demos.com/assets/dizzy.mp4",
         "subtitle_uri": "https://storage.googleapis.com/exoplayer-test-media-1/ttml/netflix_ttml_sample.xml",

--- a/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/FragmentedMp4Extractor.java
+++ b/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/FragmentedMp4Extractor.java
@@ -1360,15 +1360,26 @@ public class FragmentedMp4Extractor implements Extractor {
         track.type == C.TRACK_TYPE_VIDEO
             && (flags & FLAG_WORKAROUND_EVERY_VIDEO_FRAME_IS_SYNC_FRAME) != 0;
 
+    // Some streams contain malformed text (e.g. WebVTT) samples with negative durations or sizes.
+    // For text tracks we tolerate these by clamping to 0 (effectively ignoring the malformed cue)
+    // rather than failing and dropping the whole track. Other track types still fail loudly.
+    boolean tolerateNegativeSampleValues = track.type == C.TRACK_TYPE_TEXT;
+
     int trackRunEnd = trackRunStart + fragment.trunLength[index];
     long timescale = track.timescale;
     long cumulativeTime = fragment.nextFragmentDecodeTime;
     for (int i = trackRunStart; i < trackRunEnd; i++) {
       // Use trun values if present, otherwise tfhd, otherwise trex.
       int sampleDuration =
-          checkNonNegative(sampleDurationsPresent ? trun.readInt() : defaultSampleValues.duration);
+          checkNonNegativeOrClamp(
+              sampleDurationsPresent ? trun.readInt() : defaultSampleValues.duration,
+              tolerateNegativeSampleValues,
+              "sampleDuration");
       int sampleSize =
-          checkNonNegative(sampleSizesPresent ? trun.readInt() : defaultSampleValues.size);
+          checkNonNegativeOrClamp(
+              sampleSizesPresent ? trun.readInt() : defaultSampleValues.size,
+              tolerateNegativeSampleValues,
+              "sampleSize");
       int sampleFlags =
           sampleFlagsPresent
               ? trun.readInt()
@@ -1397,12 +1408,25 @@ public class FragmentedMp4Extractor implements Extractor {
     return trackRunEnd;
   }
 
-  private static int checkNonNegative(int value) throws ParserException {
-    if (value < 0) {
-      throw ParserException.createForMalformedContainer(
-          "Unexpected negative value: " + value, /* cause= */ null);
+  /**
+   * Validates that {@code value} is non-negative.
+   *
+   * <p>If {@code value} is negative and {@code tolerate} is {@code true}, a warning is logged and 0
+   * is returned (used for malformed text/subtitle samples, so the affected cue is effectively
+   * ignored instead of dropping the whole track). Otherwise a malformed-container {@link
+   * ParserException} is thrown.
+   */
+  private static int checkNonNegativeOrClamp(int value, boolean tolerate, String field)
+      throws ParserException {
+    if (value >= 0) {
+      return value;
     }
-    return value;
+    if (tolerate) {
+      Log.w(TAG, "Clamping malformed negative " + field + " (" + value + ") to 0.");
+      return 0;
+    }
+    throw ParserException.createForMalformedContainer(
+        "Unexpected negative value: " + value, /* cause= */ null);
   }
 
   private static void parseUuid(


### PR DESCRIPTION
### Summary
  
Some DASH/fMP4 streams contain malformed text (WebVTT) samples whose trun boxes report negative sample durations or sizes. Previously FragmentedMp4Extractor threw a ParserException on the first negative value, which dropped the entire subtitle track (and could crash playback).

This change makes the extractor tolerant of these malformed values for text tracks only: a negative duration/size is clamped to 0 (effectively ignoring the bad cue) and a warning is logged. All other track types (video/audio) still fail loudly as before, so genuinely corrupt media is not silently accepted.

### Changes

  - FragmentedMp4Extractor.java
  - Replaced checkNonNegative(value) with checkNonNegativeOrClamp(value, tolerate, field).
  - For C.TRACK_TYPE_TEXT tracks, tolerate is true → negative sampleDuration/sampleSize are clamped to 0 with a Log.w warning.
  - For all other track types, behavior is unchanged (throws ParserException.createForMalformedContainer).
  - media.exolist.json (demo app)
  - Added a "DASH - malformed WebVTT (negative trun values)" sample under Subtitles to reproduce/verify the fix.

### Testing

  1. Build & run the main demo app.
  2. Open the Subtitles group → play "DASH - malformed WebVTT (negative trun values)".
  3. Before the fix: subtitle track fails to load / playback errors out.
  4. After the fix: stream plays; logcat shows Clamping malformed negative sampleDuration/sampleSize (...) to 0. warnings instead of a fatal parser exception.

### Ticket
DORIS-3076